### PR TITLE
find_package(THREADS REQUIRED), etc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,10 @@ find_package(fmt CONFIG REQUIRED)
 target_link_libraries(spdlog INTERFACE fmt::fmt)
 target_compile_definitions(spdlog INTERFACE SPDLOG_FMT_EXTERNAL=1)
 
+### threads ###
+find_package(Threads REQUIRED)
+target_link_libraries(spdlog INTERFACE Threads::Threads)
+
 option(SPDLOG_BUILD_EXAMPLES "Build examples" OFF)
 option(SPDLOG_BUILD_TESTS "Build tests" OFF)
 

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -28,6 +28,7 @@ if(@ANDROID@)
 endif()
 
 find_package(fmt REQUIRED)
+find_package(Threads REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
 check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
Background:
```
/home/travis/build/headupinclouds/hunter/examples/spdlog/foo.cpp:(.text._ZN6spdlog7details16async_log_helperC2ESt10shared_ptrINS_9formatterEERKSt6vectorIS2_INS_5sinks4sinkEESaIS8_EEmSt8functionIFvRKSsEENS_21async_overflow_policyERKSD_IFvvEERKNSt6chrono8durationIlSt5ratioILl1ELl1000EEEESM_[_ZN6spdlog7details16async_log_helperC2ESt10shared_ptrINS_9formatterEERKSt6vectorIS2_INS_5sinks4sinkEESaIS8_EEmSt8functionIFvRKSsEENS_21async_overflow_policyERKSD_IFvvEERKNSt6chrono8durationIlSt5ratioILl1ELl1000EEEESM_]+0x200): undefined reference to `pthread_create'
```